### PR TITLE
Tmc429 revision

### DIFF
--- a/tmc/helpers/Types.h
+++ b/tmc/helpers/Types.h
@@ -92,6 +92,9 @@ typedef int32_t      int32;
 #define NULL ((void *) 0)
 #endif /* NULL */
 
+#define FALSE false
+#define TRUE true
+
 #endif /* TMC_TYPES_NULL */
 
 #endif /* TMC_TYPES_H_ */

--- a/tmc/ic/TMC429/TMC429.c
+++ b/tmc/ic/TMC429/TMC429.c
@@ -194,7 +194,7 @@ uint8_t Read429SingleByte(uint8_t Address, uint8_t Index)
 }
 
 /***************************************************************//**
-	 \fn Read429Short(uint8_t Address)
+	 \fn Read429Int12(uint8_t Address)
 	 \brief Read TMC429 register (12 bit)
 	 \param Address  TMC429 register address (see TMC429.h)
 
@@ -203,7 +203,7 @@ uint8_t Read429SingleByte(uint8_t Address, uint8_t Index)
 	 This functions reads a TMC429 12 bit register and sign-extends the
 	 register value to 32 bit.
 ********************************************************************/
-int32_t Read429Short(uint8_t Address)
+int32_t Read429Int12(uint8_t Address)
 {
 	uint8_t Read[4], Write[4];
 	int32_t Result;
@@ -219,7 +219,7 @@ int32_t Read429Short(uint8_t Address)
 }
 
 /***************************************************************//**
-	 \fn Read429Int(uint8_t Address)
+	 \fn Read429Int24(uint8_t Address)
 	 \brief Read TMC429 register (24 bit)
 	 \param Address  TMC429 register address (see TMC429.h)
 
@@ -228,7 +228,7 @@ int32_t Read429Short(uint8_t Address)
 	 This functions reads a TMC429 24 bit register and sign-extends the
 	 register value to 32 bit.
 ********************************************************************/
-int32_t Read429Int(uint8_t Address)
+int32_t Read429Int24(uint8_t Address)
 {
 	uint8_t Read[4], Write[4];
 	int32_t Result;
@@ -320,9 +320,9 @@ uint8_t SetAMax(uint8_t Motor, uint32_t AMax)
 	pd = -1;
 
 	if(ramp_div >= pulse_div)
-		p = AMax / ( 128.0 * (1<<ramp_div-pulse_div));  // Exponent positive or 0
+		p = AMax / ( 128.0 * (1<<(ramp_div-pulse_div)));  // Exponent positive or 0
 	else
-		p = AMax / ( 128.0 / (1<<pulse_div-ramp_div));  // Exponent negative
+		p = AMax / ( 128.0 / (1<<(pulse_div-ramp_div)));  // Exponent negative
 
 	p_reduced = p*0.988;
 
@@ -342,7 +342,7 @@ uint8_t SetAMax(uint8_t Motor, uint32_t AMax)
 	Data[1] = (uint8_t) pm;
 	Data[2] = (uint8_t) pd;
 	Write429Bytes(TMC429_IDX_PMUL_PDIV(Motor), Data);
-	Write429Short(TMC429_IDX_AMAX(Motor), AMax);
+	Write429U16(TMC429_IDX_AMAX(Motor), AMax);
 
 	return 0;
 }
@@ -380,16 +380,16 @@ void Init429(void)
 			Write429Zero(addr | TMC429_MOTOR(motor));
 	}
 
-	Write429Int(TMC429_IDX_IF_CONFIG_429, TMC429_IFCONF_EN_SD | TMC429_IFCONF_EN_REFR | TMC429_IFCONF_SDO_INT);
+	Write429U24(TMC429_IDX_IF_CONFIG_429, TMC429_IFCONF_EN_SD | TMC429_IFCONF_EN_REFR | TMC429_IFCONF_SDO_INT);
 	Write429Datagram(TMC429_IDX_SMGP, 0x00, 0x00, 0x02);
 
 	for(motor = 0; motor < 3; motor++)
 	{
 		Write429Datagram(TMC429_IDX_PULSEDIV_RAMPDIV(motor), 0x00, 0x37, 0x06);
 		Write429Datagram(TMC429_IDX_REFCONF_RM(motor), 0x00, TMC429_NO_REF, 0x00);
-		Write429Short(TMC429_IDX_VMIN(motor), 1);
+		Write429U16(TMC429_IDX_VMIN(motor), 1);
 
-		Write429Int(TMC429_IDX_VMAX(motor), 1000);
+		Write429U24(TMC429_IDX_VMAX(motor), 1000);
 		SetAMax(motor, 1000);
 	}
 }

--- a/tmc/ic/TMC429/TMC429.h
+++ b/tmc/ic/TMC429/TMC429.h
@@ -16,13 +16,13 @@
 	void Write429Zero(uint8_t Address);
 	void Write429Bytes(uint8_t Address, uint8_t *Bytes);
 	void Write429Datagram(uint8_t Address, uint8_t HighByte, uint8_t MidByte, uint8_t LowByte);
-	void Write429Short(uint8_t Address, int Value);
-	void Write429Int(uint8_t Address, int Value);
+	void Write429U16(uint8_t Address, uint16_t Value);
+	void Write429U24(uint8_t Address, uint32_t Value);
 	uint8_t Read429Status(void);
 	uint8_t Read429Bytes(uint8_t Address, uint8_t *Bytes);
 	uint8_t Read429SingleByte(uint8_t Address, uint8_t Index);
-	int32_t Read429Short(uint8_t Address);
-	int32_t Read429Int(uint8_t Address);
+	int32_t Read429Int12(uint8_t Address);
+	int32_t Read429Int24(uint8_t Address);
 	void Set429RampMode(uint8_t Axis, uint8_t RampMode);
 	void Set429SwitchMode(uint8_t Axis, uint8_t SwitchMode);
 	uint8_t SetAMax(uint8_t Motor, uint32_t AMax);

--- a/tmc/ic/TMC429/TMC429.h
+++ b/tmc/ic/TMC429/TMC429.h
@@ -10,6 +10,9 @@
 	#include "tmc/helpers/API_Header.h"
 	#include "TMC429_Register.h"
 
+	// user must provide this function
+	uint8_t ReadWriteSPI(void* p_SPI_DeviceHandle, uint8_t data,bool endTransaction);
+
 	// TMC429 library functions
 	void Init429(void);
 	void ReadWrite429(uint8_t *Read, uint8_t *Write);


### PR DESCRIPTION
Integer types were conflicting and naming was confusing so I fixed those.
TRUE and FALSE weren't defined by my compiler so I added those to the types file so the code can build.
ReadWriteSPI function declaration was missing from header file so I added it.

The 429 driver is far from complete since it isn't written for multiple instances and the header files are not c++ compatible. In my application I have to modify every function to have an instance pointer so I can use multiple devices or I will have to convert the code to c++.