### PR TITLE
Fix a compile-time warning/error with C++ compiler

### DIFF
--- a/tmc/ic/TMC2209/TMC2209.h
+++ b/tmc/ic/TMC2209/TMC2209.h
@@ -60,7 +60,7 @@ static const uint8_t tmc2209_defaultRegisterAccess[TMC2209_REGISTER_COUNT] =
 	0x03, 0x01, 0x01, ____, ____, ____, ____, ____, ____, ____, ____, ____, ____, ____, ____, ____  // 0x70 - 0x7F
 };
 
-static const int32_t tmc2209_defaultRegisterResetState[TMC2209_REGISTER_COUNT] =
+static const uint32_t tmc2209_defaultRegisterResetState[TMC2209_REGISTER_COUNT] =
 {
 //	0    1    2    3    4    5    6    7    8    9    A    B    C    D    E    F
 	R00, 0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0, // 0x00 - 0x0F


### PR DESCRIPTION
The error is as follows:
```
In file included from /home/alex/src/xxx/src/motor_task.cpp:19:
/home/alex/src/xxx/tmc/tmc/ic/TMC2209/TMC2209.h:40:13: error: narrowing conversion of '3238854692' from 'unsigned int' to 'int32_t' {aka 'long int'} [-Wnarrowing]
   40 | #define R70 0xC10D0024  // PWMCONF
      |             ^~~~~~~~~~
/home/alex/src/xxx/tmc/tmc/ic/TMC2209/TMC2209.h:73:9: note: in expansion of macro 'R70'
   73 |         R70, 0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0  // 0x70 - 0x7F
      |         ^~~
```

The fix is simple, just use an uint32_t instead of an int32_t.