### PR TITLE
Add extern "C" wrappers around all high-level API C functions

### DIFF
--- a/tmc/helpers/CRC.h
+++ b/tmc/helpers/CRC.h
@@ -16,10 +16,18 @@
 	// Each table takes ~260 bytes (257 bytes, one bool and structure padding)
 	#define CRC_TABLE_COUNT 2
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 	uint8_t tmc_fillCRC8Table(uint8_t polynomial, bool isReflected, uint8_t index);
 	uint8_t tmc_CRC8(uint8_t *data, uint32_t bytes, uint8_t index);
 
 	uint8_t tmc_tableGetPolynomial(uint8_t index);
 	bool  tmc_tableIsReflected(uint8_t index);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* TMC_HELPERS_CRC_H_ */

--- a/tmc/helpers/Functions.h
+++ b/tmc/helpers/Functions.h
@@ -12,9 +12,17 @@
 
 #include "API_Header.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int32_t tmc_limitInt(int32_t value, int32_t min, int32_t max);
 int64_t tmc_limitS64(int64_t value, int64_t min, int64_t max);
 int32_t tmc_sqrti(int32_t x);
 int32_t tmc_filterPT1(int64_t *akku, int32_t newValue, int32_t lastValue, uint8_t actualFilter, uint8_t maxFilter);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* TMC_FUNCTIONS_H_ */

--- a/tmc/ic/MAX22216/MAX22216.h
+++ b/tmc/ic/MAX22216/MAX22216.h
@@ -28,6 +28,10 @@ typedef struct {
 	uint8_t crc_en;
 } MAX22216TypeDef;
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 uint8_t max22216_CRC(uint8_t *data, size_t length);
 
 void max22216_writeDatagram(MAX22216TypeDef *max22216, uint8_t address, uint8_t x1, uint8_t x2);
@@ -41,5 +45,9 @@ void max22216_init(MAX22216TypeDef *max22216, uint8_t channel);
 
 uint8_t max22216_getSlaveAddress(const MAX22216TypeDef *max22216);
 void max22216_setSlaveAddress(MAX22216TypeDef *max22216, uint8_t slaveAddress);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* API_IC_MAX22216_H */

--- a/tmc/ic/TMC2130/TMC2130.h
+++ b/tmc/ic/TMC2130/TMC2130.h
@@ -95,6 +95,10 @@ static const TMCRegisterConstant tmc2130_RegisterConstants[] =
 #undef R10
 #undef R6C
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // API Functions
 // All functions act on one IC identified by the TMC2130TypeDef pointer
 
@@ -109,5 +113,9 @@ uint8_t tmc2130_restore(TMC2130TypeDef *tmc2130);
 void tmc2130_setRegisterResetState(TMC2130TypeDef *tmc2130, const int32_t *resetState);
 void tmc2130_setCallback(TMC2130TypeDef *tmc2130, tmc2130_callback callback);
 void tmc2130_periodicJob(TMC2130TypeDef *tmc2130, uint32_t tick);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* TMC_IC_TMC2130_H_ */

--- a/tmc/ic/TMC2160/TMC2160.h
+++ b/tmc/ic/TMC2160/TMC2160.h
@@ -114,6 +114,10 @@ static const TMCRegisterConstant tmc2160_RegisterConstants[] =
 		{ 0x69, 0x00F70000 }  // MSLUTSTART
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void tmc2160_writeDatagram(TMC2160TypeDef *tmc2160, uint8_t address, uint8_t x1, uint8_t x2, uint8_t x3, uint8_t x4);
 void tmc2160_writeInt(TMC2160TypeDef *tmc2160, uint8_t address, int32_t value);
 int32_t tmc2160_readInt(TMC2160TypeDef *tmc2160, uint8_t address);
@@ -125,5 +129,9 @@ uint8_t tmc2160_restore(TMC2160TypeDef *tmc2160);
 void tmc2160_setRegisterResetState(TMC2160TypeDef *tmc2160, const int32_t *resetState);
 void tmc2160_setCallback(TMC2160TypeDef *tmc2160, tmc2160_callback callback);
 void tmc2160_periodicJob(TMC2160TypeDef *tmc2160, uint32_t tick);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* TMC_IC_TMC2160_H_ */

--- a/tmc/ic/TMC2208/TMC2208.h
+++ b/tmc/ic/TMC2208/TMC2208.h
@@ -72,6 +72,10 @@ static const int32_t tmc2208_defaultRegisterResetState[TMC2208_REGISTER_COUNT] =
 #undef R6C
 #undef R70
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void tmc2208_writeInt(TMC2208TypeDef *tmc2208, uint8_t address, int32_t value);
 int32_t tmc2208_readInt(TMC2208TypeDef *tmc2208, uint8_t address);
 
@@ -84,5 +88,9 @@ void tmc2208_periodicJob(TMC2208TypeDef *tmc2208, uint32_t tick);
 
 uint8_t tmc2208_get_slave(TMC2208TypeDef *tmc2208);
 void tmc2208_set_slave(TMC2208TypeDef *tmc2208, uint8_t slave);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* TMC_IC_TMC2208_H_ */

--- a/tmc/ic/TMC2209/TMC2209.h
+++ b/tmc/ic/TMC2209/TMC2209.h
@@ -83,6 +83,10 @@ static const int32_t tmc2209_defaultRegisterResetState[TMC2209_REGISTER_COUNT] =
 #undef R6C
 #undef R70
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // Communication
 void tmc2209_writeInt(TMC2209TypeDef *tmc2209, uint8_t address, int32_t value);
 int32_t tmc2209_readInt(TMC2209TypeDef *tmc2209, uint8_t address);
@@ -96,5 +100,9 @@ void tmc2209_periodicJob(TMC2209TypeDef *tmc2209, uint32_t tick);
 
 uint8_t tmc2209_get_slave(TMC2209TypeDef *tmc2209);
 void tmc2209_set_slave(TMC2209TypeDef *tmc2209, uint8_t slaveAddress);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* TMC_IC_TMC2209_H_ */

--- a/tmc/ic/TMC2224/TMC2224.h
+++ b/tmc/ic/TMC2224/TMC2224.h
@@ -31,6 +31,10 @@ typedef struct {
 	uint8_t slave;
 } TMC2224TypeDef;
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void tmc2224_initConfig(TMC2224TypeDef *TMC2224);
 void tmc2224_periodicJob(uint8_t motor, uint32_t tick, TMC2224TypeDef *TMC2224, ConfigurationTypeDef *TMC2224_config);
 uint8_t tmc2224_reset(TMC2224TypeDef *tmc2224, ConfigurationTypeDef *TMC2224_config);
@@ -38,5 +42,9 @@ uint8_t tmc2224_restore(ConfigurationTypeDef *TMC2224_config);
 
 uint8_t tmc2224_get_slave(TMC2224TypeDef *tmc2224);
 void tmc2224_set_slave(TMC2224TypeDef *tmc2224, uint8_t slave);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* TMC_IC_TMC2224_H_ */

--- a/tmc/ic/TMC2225/TMC2225.h
+++ b/tmc/ic/TMC2225/TMC2225.h
@@ -80,6 +80,10 @@ static const int32_t tmc2225_defaultRegisterResetState[TMC2225_REGISTER_COUNT] =
 #undef R6C
 #undef R70
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void tmc2225_writeInt(TMC2225TypeDef *tmc2225, uint8_t address, int32_t value);
 int32_t tmc2225_readInt(TMC2225TypeDef *tmc2225, uint8_t address);
 
@@ -92,5 +96,9 @@ void tmc2225_periodicJob(TMC2225TypeDef *tmc2225, uint32_t tick);
 
 uint8_t tmc2225_get_slave(TMC2225TypeDef *tmc2225);
 void tmc2225_set_slave(TMC2225TypeDef *tmc2225, uint8_t slave);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* TMC_IC_TMC2225_H_ */

--- a/tmc/ic/TMC2226/TMC2226.h
+++ b/tmc/ic/TMC2226/TMC2226.h
@@ -96,6 +96,10 @@ static const TMCRegisterConstant tmc2226_RegisterConstants[] =
 #undef R6C
 #undef R70
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // Communication
 void tmc2226_writeInt(TMC2226TypeDef *tmc2226, uint8_t address, int32_t value);
 int32_t tmc2226_readInt(TMC2226TypeDef *tmc2226, uint8_t address);
@@ -109,5 +113,9 @@ void tmc2226_periodicJob(TMC2226TypeDef *tmc2226, uint32_t tick);
 
 uint8_t tmc2226_getSlaveAddress(TMC2226TypeDef *tmc2226);
 void tmc2226_setSlaveAddress(TMC2226TypeDef *tmc2226, uint8_t slaveAddress);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* TMC_IC_TMC2226_H_ */

--- a/tmc/ic/TMC2240/TMC2240.h
+++ b/tmc/ic/TMC2240/TMC2240.h
@@ -99,6 +99,10 @@ static const TMCRegisterConstant tmc2240_RegisterConstants[] =
 		///
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void tmc2240_init(TMC2240TypeDef *tmc2240, uint8_t channel, ConfigurationTypeDef *config, const int32_t *registerResetState);
 //void tmc2240_fillShadowRegisters(TMC2240TypeDef *tmc2240);
 uint8_t tmc2240_reset(TMC2240TypeDef *tmc2240);
@@ -110,5 +114,9 @@ void tmc2240_setCallback(TMC2240TypeDef *tmc2240, tmc2240_callback callback);
 void tmc2240_periodicJob(TMC2240TypeDef *tmc2240, uint32_t tick);
 
 uint8_t tmc2240_consistencyCheck(TMC2240TypeDef *tmc2240);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* TMC_IC_TMC2240_H_ */

--- a/tmc/ic/TMC2300/TMC2300.h
+++ b/tmc/ic/TMC2300/TMC2300.h
@@ -82,6 +82,9 @@ static const TMCRegisterConstant tmc2300_RegisterConstants[] =
 		{ 0x70, 0xC40D1024 }, // PWMCONF
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 void tmc2300_writeInt(TMC2300TypeDef *tmc2300, uint8_t address, int32_t value);
 int32_t tmc2300_readInt(TMC2300TypeDef *tmc2300, uint8_t address);
@@ -98,5 +101,9 @@ void tmc2300_setSlaveAddress(TMC2300TypeDef *tmc2300, uint8_t slaveAddress);
 
 uint8_t tmc2300_getStandby(TMC2300TypeDef *tmc2300);
 void tmc2300_setStandby(TMC2300TypeDef *tmc2300, uint8_t standbyState);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* TMC_IC_TMC2300_H_ */

--- a/tmc/ic/TMC2590/TMC2590.h
+++ b/tmc/ic/TMC2590/TMC2590.h
@@ -65,11 +65,19 @@ static const int32_t tmc2590_defaultRegisterResetState[TMC2590_REGISTER_COUNT] =
 	0x000EF040   // 7: DRVCONF
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void tmc2590_init(TMC2590TypeDef *tmc2590, uint8_t channel, ConfigurationTypeDef *tmc2590_config, const int32_t *registerResetState);
 void tmc2590_periodicJob(TMC2590TypeDef *tmc2590, uint32_t tick);
 void tmc2590_writeInt(TMC2590TypeDef *tmc2590, uint8_t address, int32_t value);
 uint32_t tmc2590_readInt(TMC2590TypeDef *tmc2590, uint8_t address);
 uint8_t tmc2590_reset(TMC2590TypeDef *tmc2590);
 uint8_t tmc2590_restore(TMC2590TypeDef *tmc2590);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* TMC_IC_TMC2590_H_ */

--- a/tmc/ic/TMC262/TMC262.h
+++ b/tmc/ic/TMC262/TMC262.h
@@ -27,6 +27,10 @@
 #define TMC262_FLAG_OT    0x02
 #define TMC262_FLAG_SG    0x01
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // Access functions for TMC262
 void tmc262_initMotorDrivers(void);
 void tmc262_setStepDirMStepRes(uint8_t MicrostepResolution);
@@ -90,5 +94,9 @@ void tmc262_enable();
 void tmc262_readState(uint8_t *Phases, uint8_t *MStep, uint32_t *StallGuard, uint8_t *SmartEnergy, uint8_t *Flags);
 
 void tmc262_getSPIData(uint8_t Index, int32_t *Data);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* TMC_IC_TMC262_H_ */

--- a/tmc/ic/TMC2660/TMC2660.h
+++ b/tmc/ic/TMC2660/TMC2660.h
@@ -37,9 +37,17 @@ typedef struct {
 	int32_t registerResetState[TMC2660_REGISTER_COUNT];
 } TMC2660TypeDef;
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void tmc2660_initConfig(TMC2660TypeDef *TMC2660);
 void tmc2660_periodicJob(uint8_t motor, uint32_t tick, TMC2660TypeDef *TMC2660, ConfigurationTypeDef *TMC2660_config);
 uint8_t tmc2660_reset(TMC2660TypeDef *TMC2660, ConfigurationTypeDef *TMC2660_config);
 uint8_t tmc2660_restore(ConfigurationTypeDef *TMC2660_config);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* TMC_IC_TMC2660_H_ */

--- a/tmc/ic/TMC4210/TMC4210.h
+++ b/tmc/ic/TMC4210/TMC4210.h
@@ -18,6 +18,10 @@
 #include "tmc/helpers/API_Header.h"
 #include "TMC4210_Registers.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // TMC4210 library functions
 void Init4210(void);
 void ReadWrite4210(uint8_t *Read, uint8_t *Write);
@@ -35,5 +39,9 @@ void Set4210RampMode(uint8_t RampMode);
 void Set4210SwitchMode(uint8_t SwitchMode);
 uint8_t SetAMax(uint32_t AMax);
 void HardStop(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* TMC_IC_TMC4210_H_ */

--- a/tmc/ic/TMC424/TMC424.h
+++ b/tmc/ic/TMC424/TMC424.h
@@ -18,10 +18,18 @@
 	#include "tmc/helpers/API_Header.h"
 	#include "TMC424_Register.h"
 
+	#ifdef __cplusplus
+	extern "C" {
+	#endif
+
 	void SetEncoderPrescaler(uint8_t Index, uint32_t Prescaler, uint8_t SpecialFunctionBits);
 	int32_t ReadEncoder(uint8_t Which423, uint8_t Index);
 	void WriteEncoder(uint8_t Index, int32_t Value);
 	uint8_t ReadEncoderNullChannel(uint8_t Which424, uint8_t Index);
 	void Init424(void);
+
+	#ifdef __cplusplus
+	}
+	#endif
 
 #endif /* TMC_IC_TMC424_H_ */

--- a/tmc/ic/TMC429/TMC429.h
+++ b/tmc/ic/TMC429/TMC429.h
@@ -18,6 +18,10 @@
 	#include "tmc/helpers/API_Header.h"
 	#include "TMC429_Register.h"
 
+	#ifdef __cplusplus
+	extern "C" {
+	#endif
+
 	// user must provide this function
 	uint8_t ReadWriteSPI(void* p_SPI_DeviceHandle, uint8_t data,bool endTransaction);
 
@@ -38,5 +42,9 @@
 	void Set429SwitchMode(uint8_t Axis, uint8_t SwitchMode);
 	uint8_t SetAMax(uint8_t Motor, uint32_t AMax);
 	void HardStop(uint32_t Motor);
+
+	#ifdef __cplusplus
+	}
+	#endif
 
 #endif /* TMC_IC_TMC429_H_ */

--- a/tmc/ic/TMC4330/TMC4330.h
+++ b/tmc/ic/TMC4330/TMC4330.h
@@ -81,6 +81,9 @@ static const uint8_t tmc4330_defaultRegisterAccess[TMC4330_REGISTER_COUNT] =
 	0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x01, 0x01, 0x01, 0x02, 0x02, 0x42, 0x01  // 0x70 - 0x7F
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 // API Functions
 // All functions act on one IC given by the TMC4330TypeDef struct
@@ -110,5 +113,9 @@ void tmc4330_moveBy(TMC4330TypeDef *tmc4330, int32_t *ticks, uint32_t velocityMa
 // Helper functions
 int32_t tmc4330_discardVelocityDecimals(int32_t value);
 uint8_t tmc4330_calibrateClosedLoop(TMC4330TypeDef *tmc4330, uint8_t worker0master1);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* TMC_IC_TMC4330_H_ */

--- a/tmc/ic/TMC4331/TMC4331.h
+++ b/tmc/ic/TMC4331/TMC4331.h
@@ -81,6 +81,9 @@ static const uint8_t tmc4331_defaultRegisterAccess[TMC4331_REGISTER_COUNT] =
 	0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x01, 0x01, 0x53, 0x13, ____, 0x42, 0x01  // 0x70 - 0x7F
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 // API Functions
 // All functions act on one IC given by the TMC4331TypeDef struct
@@ -110,5 +113,9 @@ void tmc4331_moveBy(TMC4331TypeDef *tmc4331, int32_t *ticks, uint32_t velocityMa
 // Helper functions
 int32_t tmc4331_discardVelocityDecimals(int32_t value);
 uint8_t tmc4331_calibrateClosedLoop(TMC4331TypeDef *tmc4331, uint8_t worker0master1);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* TMC_IC_TMC4331_H_ */

--- a/tmc/ic/TMC4361A/TMC4361A.h
+++ b/tmc/ic/TMC4361A/TMC4361A.h
@@ -106,6 +106,10 @@ static const TMCRegisterConstant tmc4361A_RegisterConstants[] =
 		{ 0x7E, 0x00F70000 }, // START_SIN, START_SIN_90_120, DAC_OFFSET
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // API Functions
 // All functions act on one IC given by the TMC4361ATypeDef struct
 
@@ -135,5 +139,9 @@ void tmc4361A_moveBy(TMC4361ATypeDef *tmc4361A, int32_t *ticks, uint32_t velocit
 // Helper functions
 int32_t tmc4361A_discardVelocityDecimals(int32_t value);
 uint8_t tmc4361A_calibrateClosedLoop(TMC4361ATypeDef *tmc4361A, uint8_t worker0master1);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* TMC_IC_TMC4361A_H_ */

--- a/tmc/ic/TMC43xx/TMC43xx.h
+++ b/tmc/ic/TMC43xx/TMC43xx.h
@@ -188,6 +188,10 @@
 #define TMC43xx_REFCONF_DRV_AFTER_STALL    0x08000000
 #define TMC43xx_REFCONF_CIRCULAR_ENC_EN    0x80000000
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // TMC43xx access functions
 void tmc43xx_writeBytes(uint8_t Axis, uint8_t Address, uint8_t x1, uint8_t x2, uint8_t x3, uint8_t x4);
 void tmc43xx_writeInt(uint8_t Axis, uint8_t Address, int32_t Value);
@@ -201,6 +205,10 @@ uint8_t tmc43xx_getHomeInput(uint8_t Motor);
 uint8_t tmc43xx_moveToNextFullstep(uint8_t Axis);
 void tmc43xx_hardStop(uint8_t Axis);
 void tmc43xx_init(uint8_t numberOfMotors);
+
+#ifdef __cplusplus
+}
+#endif
 
 typedef struct
 {

--- a/tmc/ic/TMC457/TMC457.h
+++ b/tmc/ic/TMC457/TMC457.h
@@ -18,6 +18,10 @@
 	#include "tmc/helpers/API_Header.h"
 	#include "TMC457_Register.h"
 
+	#ifdef __cplusplus
+	extern "C" {
+	#endif
+
 	void Write457Zero(uint8_t Address);
 	void Write457Int(uint8_t Address, int32_t Value);
 	void Write457Wavetable(uint16_t RAMAddress, uint16_t Value);
@@ -27,6 +31,10 @@
 	void Init457Wavetable(uint32_t Resolution, int32_t Offset);
 	void Init457(void);
 	void HardStop();
+
+	#ifdef __cplusplus
+	}
+	#endif
 
 #endif /* TMC_IC_TMC457_H_ */
 

--- a/tmc/ic/TMC4671/TMC4671.h
+++ b/tmc/ic/TMC4671/TMC4671.h
@@ -25,6 +25,10 @@
 #define TMC4671_FIELD_UPDATE(tdef, address, mask, shift, value) \
 	(tmc4671_writeInt(tdef, address, FIELD_SET(tmc4671_readInt(tdef, address), mask, shift, value)))
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int32_t tmc4671_readInt(uint8_t motor, uint8_t address);
 void tmc4671_writeInt(uint8_t motor, uint8_t address, int32_t value);
 uint16_t tmc4671_readRegister16BitValue(uint8_t motor, uint8_t address, uint8_t channel);
@@ -103,5 +107,9 @@ void tmc4671_setVelocityPI(uint8_t motor, uint16_t pParameter, uint16_t iParamet
 void tmc4671_setPositionPI(uint8_t motor, uint16_t pParameter, uint16_t iParameter);
 
 int32_t tmc4671_readFieldWithDependency(uint8_t motor, uint8_t reg, uint8_t dependsReg, uint32_t dependsValue, uint32_t mask, uint8_t shift);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* TMC_IC_TMC4671_H_ */

--- a/tmc/ic/TMC5031/TMC5031.h
+++ b/tmc/ic/TMC5031/TMC5031.h
@@ -31,9 +31,17 @@ typedef struct {
 	bool vMaxModified[2];
 } TMC5031TypeDef;
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void tmc5031_initConfig(TMC5031TypeDef *TMC5031);
 void tmc5031_periodicJob(uint8_t motor, uint32_t tick, TMC5031TypeDef *TMC5031, ConfigurationTypeDef *TMC5031_config);
 uint8_t tmc5031_reset(ConfigurationTypeDef *TMC5031_config);
 uint8_t tmc5031_restore(ConfigurationTypeDef *TMC5031_config);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* TMC_IC_TMC5031_H_ */

--- a/tmc/ic/TMC5041/TMC5041.h
+++ b/tmc/ic/TMC5041/TMC5041.h
@@ -101,6 +101,10 @@ static const int32_t tmc5041_defaultRegisterResetState[TMC5041_REGISTER_COUNT] =
 #undef R6C
 #undef R7C
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void tmc5041_writeDatagram(TMC5041TypeDef *tmc5041, uint8_t address, uint8_t x1, uint8_t x2, uint8_t x3, uint8_t x4);
 void tmc5041_writeInt(TMC5041TypeDef *tmc5041, uint8_t address, int32_t value);
 int32_t tmc5041_readInt(TMC5041TypeDef *tmc5041, uint8_t address);
@@ -109,5 +113,9 @@ void tmc5041_init(TMC5041TypeDef *tmc5041, uint8_t channel, ConfigurationTypeDef
 void tmc5041_periodicJob(TMC5041TypeDef *tmc5041, uint32_t tick);
 uint8_t tmc5041_reset(TMC5041TypeDef *tmc5041);
 uint8_t tmc5041_restore(TMC5041TypeDef *tmc5041);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* TMC_IC_TMC5041_H_ */

--- a/tmc/ic/TMC5062/TMC5062.h
+++ b/tmc/ic/TMC5062/TMC5062.h
@@ -110,6 +110,10 @@ static const TMCRegisterConstant tmc5062_RegisterConstants[] =
 		{ 0x79, 0x00F70000 }  // MSLUTSTART_M2
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void tmc5062_writeInt(TMC5062TypeDef *tmc5062, uint8_t channel, uint8_t address, int32_t value);
 int32_t tmc5062_readInt(TMC5062TypeDef *tmc5062, uint8_t channel, uint8_t address);
 
@@ -164,5 +168,9 @@ uint8_t setMicroStepTable(TMC5062TypeDef *tmc5062, uint8_t channel, TMC5062_Micr
 
 // Encoder
 uint32_t setEncoderFactor(TMC5062TypeDef *tmc5062, uint8_t channel, uint32_t motorFullSteps, uint32_t microSteps, uint32_t encoderResolution);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* TMC_IC_TMC5062_H_ */

--- a/tmc/ic/TMC5072/TMC5072.h
+++ b/tmc/ic/TMC5072/TMC5072.h
@@ -100,6 +100,10 @@ static const TMCRegisterConstant tmc5072_RegisterConstants[] =
 		{ 0x69, 0x00F70000 }  // MSLUTSTART
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void tmc5072_writeDatagram(TMC5072TypeDef *tmc5072, uint8_t address, uint8_t x1, uint8_t x2, uint8_t x3, uint8_t x4);
 void tmc5072_writeInt(TMC5072TypeDef *tmc5072, uint8_t address, int32_t value);
 int32_t tmc5072_readInt(TMC5072TypeDef *tmc5072, uint8_t address);
@@ -118,5 +122,9 @@ void tmc5072_left(TMC5072TypeDef *tmc5072, uint8_t motor, int32_t velocity);
 void tmc5072_stop(TMC5072TypeDef *tmc5072, uint8_t motor);
 void tmc5072_moveTo(TMC5072TypeDef *tmc5072, uint8_t motor, int32_t position, uint32_t velocityMax);
 void tmc5072_moveBy(TMC5072TypeDef *tmc5072, uint8_t motor, uint32_t velocityMax, int32_t *ticks);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* TMC_IC_TMC5072_H_ */

--- a/tmc/ic/TMC5130/TMC5130.h
+++ b/tmc/ic/TMC5130/TMC5130.h
@@ -97,6 +97,10 @@ static const TMCRegisterConstant tmc5130_RegisterConstants[] =
 		{ 0x70, 0x00050480 }  // PWMCONF
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // API Functions
 // All functions act on one IC identified by the TMC5130TypeDef pointer
 
@@ -118,5 +122,9 @@ void tmc5130_left(TMC5130TypeDef *tmc5130, uint32_t velocity);
 void tmc5130_stop(TMC5130TypeDef *tmc5130);
 void tmc5130_moveTo(TMC5130TypeDef *tmc5130, int32_t position, uint32_t velocityMax);
 void tmc5130_moveBy(TMC5130TypeDef *tmc5130, int32_t *ticks, uint32_t velocityMax);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* TMC_IC_TMC5130_H_ */

--- a/tmc/ic/TMC5160/TMC5160.h
+++ b/tmc/ic/TMC5160/TMC5160.h
@@ -113,6 +113,10 @@ static const TMCRegisterConstant tmc5160_RegisterConstants[] =
 		{ 0x70, 0xC40C001E }  // PWMCONF
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void tmc5160_writeDatagram(TMC5160TypeDef *tmc5160, uint8_t address, uint8_t x1, uint8_t x2, uint8_t x3, uint8_t x4);
 void tmc5160_writeInt(TMC5160TypeDef *tmc5160, uint8_t address, int32_t value);
 int32_t tmc5160_readInt(TMC5160TypeDef *tmc5160, uint8_t address);
@@ -133,5 +137,9 @@ void tmc5160_moveTo(TMC5160TypeDef *tmc5160, int32_t position, uint32_t velocity
 void tmc5160_moveBy(TMC5160TypeDef *tmc5160, int32_t *ticks, uint32_t velocityMax);
 
 uint8_t tmc5160_consistencyCheck(TMC5160TypeDef *tmc5160);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* TMC_IC_TMC5160_H_ */

--- a/tmc/ic/TMC5240/TMC5240.h
+++ b/tmc/ic/TMC5240/TMC5240.h
@@ -109,6 +109,10 @@ static const TMCRegisterConstant tmc5240_RegisterConstants[] =
 		///
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 //void tmc5240_writeDatagram(TMC5240TypeDef *tmc5240, uint8_t address, uint8_t x1, uint8_t x2, uint8_t x3, uint8_t x4);
 void tmc5240_writeInt(TMC5240TypeDef *tmc5240, uint8_t address, int32_t value);
 int32_t tmc5240_readInt(TMC5240TypeDef *tmc5240, uint8_t address);
@@ -129,5 +133,9 @@ void tmc5240_left(TMC5240TypeDef *tmc5240, uint32_t velocity);
 void tmc5240_stop(TMC5240TypeDef *tmc5240);
 void tmc5240_moveTo(TMC5240TypeDef *tmc5240, int32_t position, uint32_t velocityMax);
 void tmc5240_moveBy(TMC5240TypeDef *tmc5240, int32_t *ticks, uint32_t velocityMax);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* TMC_IC_TMC5240_H_ */

--- a/tmc/ic/TMC5271/TMC5271.h
+++ b/tmc/ic/TMC5271/TMC5271.h
@@ -105,6 +105,10 @@ static const TMCRegisterConstant tmc5271_RegisterConstants[] =
 		///
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 //void tmc5271_writeDatagram(TMC5271TypeDef *tmc5271, uint8_t address, uint8_t x1, uint8_t x2, uint8_t x3, uint8_t x4);
 void tmc5271_writeInt(TMC5271TypeDef *tmc5271, uint8_t address, int32_t value);
 int32_t tmc5271_readInt(TMC5271TypeDef *tmc5271, uint8_t address);
@@ -128,5 +132,9 @@ void tmc5271_moveBy(TMC5271TypeDef *tmc5271, uint8_t motor, uint32_t velocityMax
 
 
 uint8_t tmc5271_consistencyCheck(TMC5271TypeDef *tmc5271);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* TMC_IC_TMC5271_H_ */

--- a/tmc/ic/TMC5272/TMC5272.h
+++ b/tmc/ic/TMC5272/TMC5272.h
@@ -62,6 +62,9 @@ typedef void (*tmc5272_callback)(TMC5272TypeDef*, ConfigState);
 #define R70 0xC44C001E  // PWMCONF
 #define R74 0x00000000  // PWMCONF
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 //void tmc5272_writeDatagram(TMC5272TypeDef *tmc5272, uint8_t address, uint8_t x1, uint8_t x2, uint8_t x3, uint8_t x4);
 void tmc5272_writeInt(TMC5272TypeDef *tmc5272, uint8_t address, int32_t value);
@@ -86,5 +89,9 @@ void tmc5272_moveBy(TMC5272TypeDef *tmc5272, uint8_t motor, uint32_t velocityMax
 
 
 uint8_t tmc5272_consistencyCheck(TMC5272TypeDef *tmc5272);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* TMC_IC_TMC5272_H_ */

--- a/tmc/ic/TMC6100/TMC6100.h
+++ b/tmc/ic/TMC6100/TMC6100.h
@@ -15,7 +15,15 @@
 #include "TMC6100_Register.h"
 #include "TMC6100_Fields.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int32_t tmc6100_readInt(uint8_t motor, uint8_t address);
 void tmc6100_writeInt(uint8_t motor, uint8_t address, int32_t value);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* TMC_IC_TMC6630_H_ */

--- a/tmc/ic/TMC6200/TMC6200.h
+++ b/tmc/ic/TMC6200/TMC6200.h
@@ -21,7 +21,15 @@
 #define TMC6200_FIELD_UPDATE(tdef, address, mask, shift, value) \
 	(tmc6200_writeInt(tdef, address, FIELD_SET(tmc6200_readInt(tdef, address), mask, shift, value)))
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int32_t tmc6200_readInt(uint8_t motor, uint8_t address);
 void tmc6200_writeInt(uint8_t motor, uint8_t address, int32_t value);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* TMC_IC_TMC6630_H_ */

--- a/tmc/ic/TMC7300/TMC7300.h
+++ b/tmc/ic/TMC7300/TMC7300.h
@@ -84,6 +84,10 @@ static const TMCRegisterConstant tmc7300_registerConstants[] =
 };
 
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void tmc7300_writeInt(TMC7300TypeDef *tmc7300, uint8_t address, int32_t value);
 int32_t tmc7300_readInt(TMC7300TypeDef *tmc7300, uint8_t address);
 
@@ -101,5 +105,9 @@ uint8_t tmc7300_getStandby(TMC7300TypeDef *tmc7300);
 void tmc7300_setStandby(TMC7300TypeDef *tmc7300, uint8_t standbyState);
 
 uint8_t tmc7300_consistencyCheck(TMC7300TypeDef *tmc7300);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* TMC_IC_TMC7300_H_ */

--- a/tmc/ic/TMC8461/TMC8461.h
+++ b/tmc/ic/TMC8461/TMC8461.h
@@ -27,6 +27,10 @@ typedef struct {
 	ConfigurationTypeDef *config_mfc;
 } TMC8461TypeDef;
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // Preparation functions to prepare r/w access on specific registers
 void tmc8461_esc_read(TMC8461TypeDef *tmc8461, uint16_t address);
 void tmc8461_esc_write(TMC8461TypeDef *tmc8461, uint16_t address);
@@ -58,5 +62,9 @@ void tmc8461_mfc_write_auto(TMC8461TypeDef *tmc8461, uint16_t address, uint8_t *
  * @param tmc8461_config_mfc The configuration for the MFC block
  */
 void tmc8461_initConfig(TMC8461TypeDef *tmc8461, ConfigurationTypeDef *tmc8461_config_esc, ConfigurationTypeDef *tmc8461_config_mfc);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* TMC_IC_TMC8461_H_ */

--- a/tmc/ic/TMC8462/TMC8462.h
+++ b/tmc/ic/TMC8462/TMC8462.h
@@ -27,6 +27,10 @@ typedef struct {
 	ConfigurationTypeDef *config_mfc;
 } TMC8462TypeDef;
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // Preparation functions to prepare r/w access on specific registers
 void tmc8462_esc_read(TMC8462TypeDef *tmc8462, uint16_t address);
 void tmc8462_esc_write(TMC8462TypeDef *tmc8462, uint16_t address);
@@ -58,5 +62,9 @@ void tmc8462_mfc_write_auto(TMC8462TypeDef *tmc8462, uint16_t address, uint8_t *
  * @param tmc8462_config_mfc The configuration for the MFC block
  */
 void tmc8462_initConfig(TMC8462TypeDef *tmc8462, ConfigurationTypeDef *tmc8462_config_esc, ConfigurationTypeDef *tmc8462_config_mfc);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* TMC_IC_TMC8462_H_ */

--- a/tmc/ramp/LinearRamp.h
+++ b/tmc/ramp/LinearRamp.h
@@ -27,8 +27,16 @@
 		uint8_t rampEnabled;
 	} TMC_LinearRamp;
 
+	#ifdef __cplusplus
+	extern "C" {
+	#endif
+
 	void tmc_linearRamp_init(TMC_LinearRamp *linearRamp);
 	void tmc_linearRamp_computeRampVelocity(TMC_LinearRamp *linearRamp);
 	void tmc_linearRamp_computeRampPosition(TMC_LinearRamp *linearRamp);
+
+	#ifdef __cplusplus
+	}
+	#endif
 
 #endif /* TMC_LINEAR_RAMP_H_ */

--- a/tmc/ramp/LinearRamp1.h
+++ b/tmc/ramp/LinearRamp1.h
@@ -54,6 +54,10 @@ typedef struct
 	uint32_t stopVelocity;
 } TMC_LinearRamp;
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void tmc_ramp_linear_init(TMC_LinearRamp *linearRamp);
 int32_t tmc_ramp_linear_compute(TMC_LinearRamp *linearRamp);
 int32_t tmc_ramp_linear_compute_velocity(TMC_LinearRamp *linearRamp);
@@ -85,5 +89,9 @@ uint32_t tmc_ramp_linear_get_acceleration_limit(TMC_LinearRamp *linearRamp);
 uint32_t tmc_ramp_linear_get_velocity_limit(TMC_LinearRamp *linearRamp);
 uint32_t tmc_ramp_linear_get_homingDistance(TMC_LinearRamp *linearRamp);
 uint32_t tmc_ramp_linear_get_stopVelocity(TMC_LinearRamp *linearRamp);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* TMC_RAMP_LINEARRAMP1_H_ */

--- a/tmc/ramp/Ramp.h
+++ b/tmc/ramp/Ramp.h
@@ -16,6 +16,10 @@ typedef enum {
 	TMC_RAMP_TYPE_LINEAR
 } TMC_RampType;
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // Initializes ramp parameters for given type
 void tmc_ramp_init(void *ramp, TMC_RampType type);
 
@@ -36,5 +40,9 @@ int32_t tmc_ramp_get_rampPosition(void *ramp, TMC_RampType type);
 bool tmc_ramp_get_enabled(void *ramp, TMC_RampType type);
 void tmc_ramp_set_enabled(void *ramp, TMC_RampType type, bool enabled);
 void tmc_ramp_toggle_enabled(void *ramp, TMC_RampType type);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* TMC_RAMP_RAMP_H_ */


### PR DESCRIPTION
This change allows to call the various high-level API C function from C++ code.
This change is transparent to any C language consumers.

I tried my best to keep the various formatting styles with indentation, empty lines and line endings consistent.